### PR TITLE
fix: manifest syntax error

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -10,7 +10,7 @@
       manifest.json provides metadata used when your web app is installed on a
       user's mobile device or desktop. See https://developers.google.com/web/fundamentals/web-app-manifest/
     -->
-    <link rel="manifest" href="%PUBLIC_URL%/manifest.json" />
+    <!-- <link rel="manifest" href="%PUBLIC_URL%/manifest.json" /> -->
     <!--
       Notice the use of %PUBLIC_URL% in the tags above.
       It will be replaced with the URL of the `public` folder during the build.


### PR DESCRIPTION
## 관련문서
close #25 

## 변경사항
- manifest.json 이 index.html와 같은 경로에 존재해야하는데 존재하지 않아서 link tag 삭제

## 참고
https://bobbyhadz.com/blog/manifest-line-1-column-1-syntax-error